### PR TITLE
Update the style guide for 2023

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _templates
 _static
 .DS_Store
 .cache
+.idea

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Documentation lives at `Read the Docs
 License
 =======
 
-Copyright 2016 Mulberry Health Inc.
+Copyright 2023 Mulberry Health Inc.
 
 Licensed under the `Apache License, Version
 2.0. <http://www.apache.org/licenses/LICENSE-2.0>`_

--- a/python.rst
+++ b/python.rst
@@ -13,9 +13,12 @@ auto-formatter to avoid having to worry (or even worse, argue!) about
 formatting. We recommend using it, but it does not cover everything
 here.
 
-Code of Conduct
+Code of conduct
 ===============
 
+- Be polite and respectful.
+- Don’t make assumptions—be clear and concise.
+- Your coworkers deserve a response to comments, questions or concerns, even if it is to respectfully decline or dissent.
 - Boy Scout Rule: Always check a module in cleaner than you checked it
   out. Clean-up and compliance to the style guide is the
   responsibility of whoever touches the code.

--- a/python.rst
+++ b/python.rst
@@ -168,17 +168,16 @@ Good
 
 
 
-- When you write new classes or modules, make sure to name them in a
-  way that reads well when imported this way, instead of being redundant.
+- When naming your classes and functions, avoid repeating details that are already clear from the module name.
 
 Good
 ++++
 
 .. code-block:: python
 
-   from provider_data import kafka
+   from provider_data import kafka_consumer
 
-   kafka.BatchedConsumer(batch_size=5)
+   kafka_consumer.Batched(batch_size=5)
 
 Bad
 +++

--- a/python.rst
+++ b/python.rst
@@ -595,7 +595,7 @@ Descriptor Protocol
 - Descriptors are useful and powerful, but also difficult to
   debug. Each possible invocation should be thoroughly tested and
   understood. See:
-  https://docs.python.org/2/howto/descriptor.html#invoking-descriptors
+  https://docs.python.org/3/howto/descriptor.html#invoking-descriptors
 
 Monkey Patching
 ~~~~~~~~~~~~~~~
@@ -736,6 +736,9 @@ Strings
 -------
 
 - Prefer f-strings over ``.format()`` or ``%``.
+
+- Pull elaborate input strings (function calls, indexing, ", ".join, etc) into
+  named variables instead of writing them inline (as a format() arg, or in an f-string, etc)
   
 - Use utf-8 characters directly instead of their byte representations
   or html entity tags. ex: u'Put é instead of \xe9'
@@ -757,18 +760,18 @@ Resources
 Inversion of Control and Dependency Injection
 ---------------------------------------------
 
-- Inject objects and resources versus creating them. This will
-  simplify testing (injectable mocks versus patching) and increase
+- Inject objects and resources versus creating them. This
+  simplifies testing (injectable mocks versus patching) and increases
   flexibility (injected objects and resources need only meet an
   interface).
 
-- You can keep your method signatures simple by injecting the
-  dependencies in the constructor. This is a good idea for objects that
-  are instantiated once and used many times. For example, a class
+- You can simplify your method signatures by injecting
+  dependencies in the constructor, especially for objects that are
+  instantiated once and used many timees. For example, a class
   might take a gRPC client in its constructor and use it to implement
   its methods - this lets setup code worry about creating the client,
-  and business logic code can call the methods of the instantiated
-  class without knowing about the client.
+  and lets business code call the methods without knowing about which
+  gRPC client(s) they depend on.
 
 - It’s a one-liner to add object creation to a function that
   accepts an object as an argument; the converse requires rewriting
@@ -779,16 +782,14 @@ Constructors
 
 - Use `dataclasses <https://docs.python.org/3/library/dataclasses.html>`_
   to create simple data objects.
+  
+- Avoid doing failable operations like file IO or network calls in a constructor.
 
-- Limit the amount of “real work” done in a constructor. Dependency
-  injection is a tremendous help here.
-
-- If an object requires expensive initialization (e.g. the creation of
-  a zookeeper session, communication over the network, file IO,
-  concurrency) use a separate classmethod to initialize the object. Also
-  consider the thread/concurrency safety of this initializer
-  function. Remember that an object may be created elsewhere as a
-  side-effect of module import.
+- If those operations were to initialize a dependency like a database connection,
+  instead do that somewhere near main() and pass it to your constructor fully-formed.
+  
+- In simple cases (like reading an environment variable), a decent compromise can be
+  to do the IO in a ``@classmethod`` which then constructs and returns the instance.
 
 Naming
 ------

--- a/python.rst
+++ b/python.rst
@@ -60,7 +60,7 @@ Use pytest-style asserts in unit tests
 - Parameterize tests instead of copy-pasting or using
   for loops.
 
-    .. code-block::python
+    .. code-block:: python
 
             # Good
             @parameterized([

--- a/python.rst
+++ b/python.rst
@@ -273,9 +273,13 @@ Do not catch-all without re-raising
 Do not use ``assert`` outside of tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Use ``raise`` instead.
+
 - The python interpreter removes ``assert``  statements when we
-  run it with the ``-O`` flag. We use that flag in production.
-  Use ``raise`` instead.
+  run it with the ``-O`` flag. This is because ``assert``
+  statements, as a language feature, are not intended to be used
+  for production logic. We plan to run our prod code with the
+  ``-O`` flag.
 
 Nested classes and functions
 ----------------------------

--- a/python.rst
+++ b/python.rst
@@ -60,8 +60,8 @@ Use pytest-style asserts in unit tests
         with self.assertRaises(SomeException):
             do_something()
 
-- Parameterize tests instead of copy-pasting or using
-  for loops.
+- If the logic for testing your different inputs is identical, prefer parameterized tests
+  instead of for loops or copy paste. That way, each test can run independently.
 
     .. code-block:: python
 
@@ -91,6 +91,7 @@ Use pytest-style asserts in unit tests
 - `Familiarize yourself with pytest's <https://docs.pytest.org/en/7.2.x/getting-started.html#create-your-first-test>`_
   features. For example, you can just write test functions at the top level instead of needing to subclass
   ``unittest.TestCase``.
+- Prefer consistency with surrounding code. If you are editing a test with unittest-style asserts, and don't plan to switch all of them, write your edits in that style too.
 
 Lint
 ----


### PR DESCRIPTION
* advise teams to use the clearer style of asserts which our test runner recommends
* fix "use asserts in prod" advice, which was just plain incorrect
* gently recommend teams use black
* remove advice that was only relevant for py2
* remove thrift advice
* simplify prose